### PR TITLE
feat: Implement endpoint to GET rejection reasons

### DIFF
--- a/src/ValidationPanelPage.jsx
+++ b/src/ValidationPanelPage.jsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { CourseValidationRequestForm, Header, ValidationTableLayout } from './components';
 
 import messages from './messages';
-import { getCurrentUserInfo } from './data/slices/userInfoSlice';
+import { getAvailableRejectionReasons, getCurrentUserInfo } from './data/slices';
 
 const ValidationPanelPage = () => {
   const [isOpen, open, close] = useToggle(false);
@@ -16,6 +16,7 @@ const ValidationPanelPage = () => {
   const isValidator = useSelector((state) => state.userInfo.userInfo.isValidator);
   useEffect(() => {
     dispatch(getCurrentUserInfo());
+    dispatch(getAvailableRejectionReasons());
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -29,6 +29,11 @@ export async function getUserInfo() {
   return camelCaseObject(data);
 }
 
+export async function getRejectionReasons() {
+  const { data } = await getAuthenticatedHttpClient().get(getValidationApiUrl(VALIDATION_API_PATH.REJECTION_REASONS));
+  return camelCaseObject(data);
+}
+
 /**
  * Fetches all the validation records created by the current user or related to a validation body.
  *  * @param {object} params

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -33,6 +33,7 @@ const VALIDATION_API_PATH = {
   VALIDATION_PROCESS: 'validation-processes',
   VALIDATION_EVENT: 'validation-process-event',
   USER_INFO: 'user-info',
+  REJECTION_REASONS: 'rejection-reasons',
 };
 
 const REQUEST_STATUS = {

--- a/src/data/slices/index.js
+++ b/src/data/slices/index.js
@@ -1,6 +1,7 @@
 export * from './categoriesSlice';
 export * from './coursesSlice';
 export * from './currentValidationRecordSlice';
+export * from './rejectionReasonsSlice';
 export * from './userInfoSlice';
 export * from './validationRecordSlice';
 export * from './validatorBodySlice';

--- a/src/data/slices/rejectionReasonsSlice.js
+++ b/src/data/slices/rejectionReasonsSlice.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-param-reassign */
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { getRejectionReasons } from '../api';
+import { REQUEST_STATUS } from '../constants';
+
+export const getAvailableRejectionReasons = createAsyncThunk('validationProcess/rejectionReasons', async () => {
+  const response = await getRejectionReasons();
+  return response;
+});
+
+const rejectionReasons = {
+  loadStatus: 'idle',
+  data: [],
+  error: {},
+};
+
+export const rejectionReasonsSlice = createSlice({
+  name: 'rejectionReasons',
+  initialState: rejectionReasons,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(getAvailableRejectionReasons.pending, (state) => {
+      state.loadStatus = REQUEST_STATUS.LOADING;
+      state.data = [];
+      state.error = {};
+    });
+    builder.addCase(getAvailableRejectionReasons.fulfilled, (state, action) => {
+      state.loadStatus = REQUEST_STATUS.LOADED;
+      state.data = action.payload;
+      state.error = {};
+    });
+    builder.addCase(getAvailableRejectionReasons.rejected, (state, action) => {
+      state.loadStatus = REQUEST_STATUS.FAILED;
+      state.data = [];
+      state.error = action.error;
+    });
+  },
+});
+
+export const rejectionReasonsReducer = rejectionReasonsSlice.reducer;

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -7,6 +7,7 @@ import {
   validationRecordReducer,
   currentValidationRecordReducer,
   userInfoReducer,
+  rejectionReasonsReducer,
 } from './slices';
 
 export const initializeStore = (preloadedState = undefined) => (
@@ -18,6 +19,7 @@ export const initializeStore = (preloadedState = undefined) => (
       validationBody: validationBodiesReducer,
       currentValidationRecord: currentValidationRecordReducer,
       userInfo: userInfoReducer,
+      rejectionReasons: rejectionReasonsReducer,
     },
     preloadedState,
   })


### PR DESCRIPTION
## Description
This PR implements the GET endpoint for obtaining the rejection reasons from the new endpoint created in the [PR #19](https://github.com/eduNEXT/platform-global-teacher-campus/pull/19) of the Plugin CWV

## How to test
Make sure you have some rejection reasons in your DDBB. They are shown and could be added in the following admin panel section
http://local.overhang.io:8000/admin/platform_global_teacher_campus/validationrejectionreason/

Add in the file ValidationPanelPage.jsx the following lines
```jsx
  const rejectionReasons = useSelector((state) => state.rejectionReasons.data);
  console.log('REJECTION REASONS', rejectionReasons);
```

Then you will watch in the browser console a printing of an array with the rejection reason you have in your DDBB. This information is gotten through the rejection-reasons endpoint and loads the global status with an async action
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/9061bfb0-83d7-4a3c-a45f-9412d7f1715d)
