### PR TITLE
feat: allow validators to choose a reason when disapproving a validation process

### DIFF
--- a/src/components/CourseValidationRequestForm/helpers.js
+++ b/src/components/CourseValidationRequestForm/helpers.js
@@ -1,10 +1,10 @@
+import { adaptOptions } from '../../utils/helpers';
+
 export const getAdaptedData = (formData, availableCourseCategories) => ({
   ...formData,
   categoryIds: formData.categoryIds.map((categoryName) => (
     availableCourseCategories.find(category => category.name === categoryName).id)),
 });
-
-export const adaptOptions = (optionsToAdapt) => optionsToAdapt?.map((option) => ({ key: option.name.replaceAll(' ', ''), id: option.id, label: option.name }));
 
 export const getCourseValidationRequestForm = (
   availableUserCourses,

--- a/src/components/ValidationProcess/FormLayout/FormField.jsx
+++ b/src/components/ValidationProcess/FormLayout/FormField.jsx
@@ -8,7 +8,7 @@ const COL_WIDTH = '50%';
 const FULL_WIDTH = '100%';
 
 const FormField = ({
-  field, values, handleChange, disableReason, isValidator, submissionDate,
+  field, values, handleChange, disableReason, isValidator, submissionDate, errorMessage,
 }) => {
   const isDisabled = !isValidator || field.disabled || (field?.name === 'reason' && disableReason);
   const isColumn = field.type === 'col';
@@ -25,10 +25,12 @@ const FormField = ({
           handleChange={handleChange}
           value={values[field.name]}
           type={field.type}
+          errorMessage={errorMessage}
         />
       ) : (
         <FormInput
           disabled={isDisabled}
+          errorMessage={errorMessage}
           name={field.name}
           handleChange={handleChange}
           value={formatDateIfDateField(field.name, values[field.name])}
@@ -74,11 +76,13 @@ FormField.propTypes = {
   disableReason: PropTypes.bool,
   isValidator: PropTypes.bool.isRequired,
   submissionDate: PropTypes.shape({ value: PropTypes.string, label: PropTypes.string }),
+  errorMessage: PropTypes.string,
 };
 
 FormField.defaultProps = {
   disableReason: false,
   submissionDate: { value: '' },
+  errorMessage: '',
 };
 
 export default FormField;

--- a/src/components/ValidationProcess/FormLayout/FormInput/FormInput.jsx
+++ b/src/components/ValidationProcess/FormLayout/FormInput/FormInput.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { Form, Stack } from '@edx/paragon';
 
 const FormInput = ({
-  handleChange, name, value, disabled, label, labelAssistant,
+  handleChange, name, value, disabled, label, labelAssistant, errorMessage,
 }) => (
   <Form.Group>
     <Form.Label className="w-100">
@@ -13,6 +13,7 @@ const FormInput = ({
     </Form.Label>
     <Form.Control
       as={label.toLowerCase().includes('comment') ? 'textarea' : 'input'}
+      isInvalid={!!errorMessage}
       autoResize
       size="sm"
       name={name}
@@ -20,6 +21,7 @@ const FormInput = ({
       value={Array.isArray(value) ? value.join(', ') : value}
       disabled={disabled}
     />
+    <Form.Control.Feedback hidden={!errorMessage} type="invalid">{errorMessage}</Form.Control.Feedback>
   </Form.Group>
 );
 
@@ -30,12 +32,14 @@ FormInput.propTypes = {
   disabled: PropTypes.bool,
   handleChange: PropTypes.func.isRequired,
   value: PropTypes.oneOfType(PropTypes.string, PropTypes.arrayOf(PropTypes.string)),
+  errorMessage: PropTypes.string,
 };
 
 FormInput.defaultProps = {
   labelAssistant: null,
   disabled: false,
   value: '',
+  errorMessage: '',
 };
 
 export default FormInput;

--- a/src/components/ValidationProcess/FormLayout/FormLayout.jsx
+++ b/src/components/ValidationProcess/FormLayout/FormLayout.jsx
@@ -12,13 +12,17 @@ import { disableReasonField } from '../helpers';
 import FormField from './FormField';
 
 const FormLayout = ({
-  data, useSpecialDateUsage, onSubmit, onCancel, isExempted,
+  data, useSpecialDateUsage, onSubmit, onCancel, isExempted, validationSchema,
 }) => {
   const isValidator = useSelector((state) => state.userInfo.userInfo.isValidator);
   const [disableReason, setDisableReason] = useState();
-  const { handleChange, values, handleSubmit } = useFormik({
+
+  const {
+    handleChange, values, handleSubmit, errors, touched,
+  } = useFormik({
     initialValues: getFormValues(data, isValidator),
     onSubmit,
+    validationSchema,
   });
 
   useEffect(() => {
@@ -43,11 +47,12 @@ const FormLayout = ({
         disableReason={disableReason}
         isValidator={isValidator}
         submissionDate={submissionDate}
+        errorMessage={touched[field.name] && errors[field.name]}
       />
     ));
 
   return (
-    <Stack direction="horizontal" className="justify-content-between flex-wrap">
+    <Stack direction="horizontal" className="justify-content-between align-items-start flex-wrap">
       {fields}
       {isValidator && (
       <Stack direction="horizontal" gap={2} className="w-100 justify-content-end mt-4">
@@ -76,6 +81,7 @@ FormLayout.propTypes = {
   onSubmit: PropTypes.func,
   onCancel: PropTypes.func,
   isExempted: PropTypes.bool,
+  validationSchema: PropTypes.shape(),
 };
 
 FormLayout.defaultProps = {
@@ -83,6 +89,7 @@ FormLayout.defaultProps = {
   onSubmit: null,
   onCancel: null,
   isExempted: false,
+  validationSchema: null,
 };
 
 export default FormLayout;

--- a/src/components/ValidationProcess/ValidationProcess.jsx
+++ b/src/components/ValidationProcess/ValidationProcess.jsx
@@ -22,6 +22,7 @@ const ValidationProcess = ({ courseSelected, onClose }) => {
   };
 
   const isValidator = useSelector((state) => state.userInfo.userInfo.isValidator);
+  const availableReasons = useSelector((state) => state.rejectionReasons.data);
 
   const submissionInfo = getSubmissionInfo(
     { ...courseSelected, courseName: courseSelected?.courseName },
@@ -73,7 +74,7 @@ const ValidationProcess = ({ courseSelected, onClose }) => {
           onClose={onClose}
           courseId={courseSelected.courseId}
           isReviewConfirmed={isReviewConfirmed}
-          lastReviewEventInfo={getLastReviewEventInfo(courseSelected)}
+          lastReviewEventInfo={getLastReviewEventInfo(courseSelected, availableReasons)}
         />
       )}
     </>

--- a/src/components/ValidationProcess/helpers.js
+++ b/src/components/ValidationProcess/helpers.js
@@ -1,12 +1,12 @@
 import { ALLOWED_STATUS_CHANGES, VALIDATION_STATUS, VALIDATION_STATUS_LABEL } from '../../data/constants';
 import { getCurrentStatusCode, getLastReviewEventInfo, PENDING_STATUSES } from '../../utils/helpers';
 
-export const getOptions = (currentStatus) => {
+export const getAllowedStatuses = (currentStatus) => {
   const currentStatusCode = getCurrentStatusCode(currentStatus);
-  const adaptedOptions = [];
+  const allowedStatuses = [];
   Object.values(VALIDATION_STATUS).forEach((opt) => {
     if (ALLOWED_STATUS_CHANGES[currentStatusCode]?.includes(opt)) {
-      adaptedOptions.push({
+      allowedStatuses.push({
         key: opt,
         id: opt,
         label: VALIDATION_STATUS_LABEL[opt],
@@ -14,7 +14,7 @@ export const getOptions = (currentStatus) => {
     }
   });
 
-  return adaptedOptions;
+  return allowedStatuses;
 };
 
 export const isPendingCourse = (course, lastReviewEventProp) => {

--- a/src/components/ValidationTable/ValidationTable.jsx
+++ b/src/components/ValidationTable/ValidationTable.jsx
@@ -20,6 +20,7 @@ import { REQUEST_STATUS, VALIDATION_ACCESS_ROLE, VALIDATION_STATUS_LABEL } from 
 const ValidationTable = ({ data, isLoading }) => {
   const dispatch = useDispatch();
   const isValidator = useSelector((state) => state.userInfo.userInfo.isValidator);
+  const availableReasons = useSelector((state) => state.rejectionReasons.data);
   const courseIdsCurrentUserIsReviewing = useSelector(
     (state) => state.validationRecord.availableValidationProcesses.courseIdsCurrentUserIsReviewing,
   );
@@ -156,7 +157,7 @@ const ValidationTable = ({ data, isLoading }) => {
         isFilterable
         defaultColumnValues={{ Filter: TextFilter }}
         itemCount={data?.length}
-        data={adaptToTableFormat(data)}
+        data={adaptToTableFormat(data, availableReasons)}
         columns={columnsWithClickableNames}
         additionalColumns={data.length ? [
           {

--- a/src/data/slices/rejectionReasonsSlice.js
+++ b/src/data/slices/rejectionReasonsSlice.js
@@ -5,7 +5,7 @@ import { REQUEST_STATUS } from '../constants';
 
 export const getAvailableRejectionReasons = createAsyncThunk('validationProcess/rejectionReasons', async () => {
   const response = await getRejectionReasons();
-  return response;
+  return Array.isArray(response) ? response : [];
 });
 
 const rejectionReasons = {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -47,13 +47,13 @@ export const getSubmissionInfo = (course) => {
   };
 };
 
-export const getLastReviewEventInfo = (course) => {
+export const getLastReviewEventInfo = (course, availableReasons) => {
   const [lastValidationProcessEvent] = getLastAndFirstValidationProcessEvents(course);
 
   return {
     reviewStartDate: lastValidationProcessEvent?.createdAt,
     status: VALIDATION_STATUS_LABEL[lastValidationProcessEvent?.status],
-    reason: lastValidationProcessEvent?.reason,
+    reason: availableReasons?.find((reason) => reason.id === lastValidationProcessEvent?.reason)?.name,
     comment: lastValidationProcessEvent?.comment,
   };
 };
@@ -92,7 +92,7 @@ const filtersToShow = ['validationBody', 'status', 'categories', 'organization']
  * @returns {Array} - An array where each course is extended with the properties
  * of the last validation process event.
  */
-export const adaptToTableFormat = (coursesToValidate) => {
+export const adaptToTableFormat = (coursesToValidate, availableReasons) => {
   const adaptedCourses = [];
 
   coursesToValidate?.forEach((course) => {
@@ -105,6 +105,7 @@ export const adaptToTableFormat = (coursesToValidate) => {
     adaptedCourses.push({
       ...course,
       ...lastValidationProcessEvent,
+      reason: availableReasons?.find((reason) => reason.id === lastValidationProcessEvent?.reason)?.name,
       user: firstValidationProcessEvent.user,
       status: VALIDATION_STATUS_LABEL[lastValidationProcessEvent.status],
       createdAt: new Date(firstValidationProcessEvent?.createdAt).toLocaleDateString('en-GB'),
@@ -219,3 +220,5 @@ export const PENDING_STATUSES = [VALIDATION_STATUS.IN_REVIEW, VALIDATION_STATUS.
 export const getCurrentStatusCode = (status) => Object.entries(
   VALIDATION_STATUS_LABEL,
 )?.find(([, value]) => value === status)?.[0];
+
+export const adaptOptions = (optionsToAdapt) => optionsToAdapt?.map((option) => ({ key: option.name.replaceAll(' ', ''), id: option.id, label: option.name }));


### PR DESCRIPTION
## Description
This PR implements the rejection reasons gotten through [this endpoint](https://github.com/eduNEXT/platform-global-teacher-campus/pull/19) for making the validators able to use them when required to update the status of a validation process to 'Disapproved'

![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/89ff997f-54d0-402e-8879-342ec4353f65)

## How to test
1. As courseAutor, submit a validation process  
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/7839b84e-2b79-43c8-963e-59c832579a94)

2. Then, as a validator, take the course to review it
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/eb860dbb-3b11-430d-9e87-fccefdd01330)

3. And access to the modal to send a validator review
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/28893e77-0b9d-421e-9cd7-2366613a4efd)

4.  Here you'll be able to...
- - ... see the form validations if something is lacking
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/8361eb01-280a-498f-b909-5019fa003858)
- - ... choose a reason if the status selected is 'Disapproved'
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/314be1e8-a23c-4399-834f-70839d848bf1)

- - ... send the validator's review by clicking on submit
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/813e001d-ecb0-43fd-91e9-df63a6247114)

## Additionals
As courseAuthor:
* refactor: apply the needed changes to show reason.name
![image](https://github.com/eduNEXT/frontend-app-validation-panel/assets/86393372/3e037d7d-9baa-4106-940a-4efb23e113b4)


