### PR TITLE
fix: course field and comment behavior

### DIFF
--- a/src/components/CourseValidationRequestForm/CourseValidationRequestForm.jsx
+++ b/src/components/CourseValidationRequestForm/CourseValidationRequestForm.jsx
@@ -79,10 +79,14 @@ const CourseValidationRequestForm = ({ isOpen, close }) => {
         }
       });
     }
+    if (!formik.values.courseId) {
+      formik.values.validationBodyId = null;
+    }
     return () => {
       isCurrent = false;
+      setAvailableValidationBodies([]);
     };
-  }, [formik.values.courseId, setAvailableValidationBodies, dispatch]);
+  }, [formik.values, setAvailableValidationBodies, dispatch]);
 
   const handleClose = () => {
     close();

--- a/src/components/CourseValidationRequestForm/CourseValidationRequestForm.jsx
+++ b/src/components/CourseValidationRequestForm/CourseValidationRequestForm.jsx
@@ -23,7 +23,7 @@ const CourseValidationRequestForm = ({ isOpen, close }) => {
   const [availableValidationBodies, setAvailableValidationBodies] = useState([]);
   const availableCourseCategories = useSelector((state) => (
     state.courseCategories.availableCourseCategories.data));
-
+  const [isLoading, setIsLoading] = useState(false);
   useEffect(() => {
     dispatch(getCoursesByUsername());
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -50,7 +50,7 @@ const CourseValidationRequestForm = ({ isOpen, close }) => {
     // When is needed category as array
     // categoryIds: Yup.array().of(Yup.string()).min(1, 'Please select at least one category!'),
     categoryId: Yup.number().required('Please select at least one category!'),
-    comment: Yup.string().required('Please insert at least a short description about your submission'),
+    comment: Yup.string(),
   });
 
   const formik = useFormik({
@@ -73,9 +73,11 @@ const CourseValidationRequestForm = ({ isOpen, close }) => {
   useEffect(() => {
     let isCurrent = true;
     if (formik.values.courseId) {
+      setIsLoading(true);
       getValidationBodies(formik.values.courseId).then((data) => {
         if (isCurrent) {
           setAvailableValidationBodies(data);
+          setIsLoading(false);
         }
       });
     }
@@ -108,6 +110,7 @@ const CourseValidationRequestForm = ({ isOpen, close }) => {
                   value={formik.values[field.name]}
                   errorMessage={formik.touched[field.name] && formik.errors[field.name]}
                   {...field}
+                  isLoading={field.name === 'validationBodyId' && isLoading}
                 />
               ))
             }

--- a/src/components/SelectField/SelectField.jsx
+++ b/src/components/SelectField/SelectField.jsx
@@ -4,8 +4,44 @@ import { Close } from '@edx/paragon/icons';
 import { Chip, Form, Stack } from '@edx/paragon';
 import { useState } from 'react';
 
+const CustomOption = ({
+  className, onClick, value, optionId, label, children,
+}) => (
+  <Stack
+    className={className}
+    onClick={(e) => {
+      e.currentTarget = { value };
+      onClick(e);
+    }}
+  >
+    <span>
+      {children}
+    </span>
+    {label.toLowerCase().includes('course') && (
+      <p className="text-gray x-small m-0">
+        {optionId}
+      </p>
+    )}
+  </Stack>
+);
+
+CustomOption.propTypes = {
+  className: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  value: PropTypes.string,
+  optionId: PropTypes.oneOfType(PropTypes.string, PropTypes.number),
+  label: PropTypes.string,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired,
+};
+
+CustomOption.defaultProps = {
+  value: '',
+  optionId: '',
+  label: '',
+};
+
 const SelectField = ({
-  label, description, name, as, options, handleChange, value, errorMessage, isArray, disabled, setFieldValue,
+  label, description, name, as, options, handleChange, value, errorMessage, isArray, isLoading, disabled, setFieldValue,
 }) => {
   const [selected, setSelected] = useState('');
   if (isArray) {
@@ -64,6 +100,7 @@ const SelectField = ({
         <span className="small">{description}</span>
         <Form.Autosuggest
           placeholder="Select one"
+          isLoading={isLoading}
           isInvalid={!!errorMessage}
           value={value ? selected : ''}
           onChange={(newValue) => {
@@ -79,8 +116,7 @@ const SelectField = ({
         >
           {options?.map((optionInfo) => (
             <Form.AutosuggestOption
-              key={optionInfo.key}
-              // eslint-disable-next-line no-use-before-define
+              key={optionInfo.id}
               as={CustomOption}
               optionId={optionInfo.id}
               label={label}
@@ -132,6 +168,7 @@ SelectField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   errorMessage: PropTypes.string,
   isArray: PropTypes.bool,
+  isLoading: PropTypes.bool,
   disabled: PropTypes.bool,
   setFieldValue: PropTypes.func,
 };
@@ -142,44 +179,9 @@ SelectField.defaultProps = {
   options: [],
   errorMessage: null,
   isArray: false,
+  isLoading: false,
   disabled: false,
   setFieldValue: () => { },
-};
-
-const CustomOption = ({
-  className, onClick, value, optionId, label, children,
-}) => (
-  <Stack
-    className={className}
-    onClick={(e) => {
-      e.currentTarget = { value };
-      onClick(e);
-    }}
-  >
-    <span>
-      {children}
-    </span>
-    {label.toLowerCase().includes('course') && (
-      <p className="text-gray x-small m-0">
-        {optionId}
-      </p>
-    )}
-  </Stack>
-);
-
-CustomOption.propTypes = {
-  className: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
-  value: PropTypes.string,
-  optionId: PropTypes.oneOfType(PropTypes.string, PropTypes.number),
-  label: PropTypes.string,
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired,
-};
-
-CustomOption.defaultProps = {
-  value: '',
-  optionId: '',
-  label: '',
 };
 
 export default SelectField;

--- a/src/components/SelectField/SelectField.jsx
+++ b/src/components/SelectField/SelectField.jsx
@@ -2,10 +2,12 @@ import PropTypes from 'prop-types';
 import { FieldArray } from 'formik';
 import { Close } from '@edx/paragon/icons';
 import { Chip, Form, Stack } from '@edx/paragon';
+import { useState } from 'react';
 
 const SelectField = ({
   label, description, name, as, options, handleChange, value, errorMessage, isArray, disabled, setFieldValue,
 }) => {
+  const [selected, setSelected] = useState('');
   if (isArray) {
     return (
       <FieldArray
@@ -63,8 +65,15 @@ const SelectField = ({
         <Form.Autosuggest
           placeholder="Select one"
           isInvalid={!!errorMessage}
+          value={value ? selected : ''}
+          onChange={(newValue) => {
+            if (newValue === '') {
+              setFieldValue(name, null); setSelected('');
+            }
+          }}
           onSelected={(newValue) => {
             const valueFound = options.find((el) => el.label === newValue);
+            setSelected(valueFound.label);
             setFieldValue(name, valueFound.id);
           }}
         >

--- a/src/components/ValidationProcess/FormLayout/FormField.jsx
+++ b/src/components/ValidationProcess/FormLayout/FormField.jsx
@@ -10,13 +10,16 @@ const FULL_WIDTH = '100%';
 const FormField = ({
   field, values, handleChange, disableReason, isValidator, submissionDate, errorMessage,
 }) => {
-  const isDisabled = !isValidator || field.disabled || (field?.name === 'reason' && disableReason);
+  const isDisabled = !isValidator || field.disabled;
   const isColumn = field.type === 'col';
 
   if (!isValidator && field.name === 'reason' && !values[field.name]) {
     return null;
   }
 
+  if (field.name === 'reason' && disableReason) {
+    return <div />;
+  }
   return (
     <div style={{ width: isColumn ? COL_WIDTH : FULL_WIDTH }} key={field.name}>
       {field.isSelect ? (

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -83,7 +83,7 @@ export async function getValidationProcess(courseId) {
 
 export async function getValidationBodies(courseId) {
   const params = courseId ? ['/', courseId].join('') : '';
-  const { data } = await getAuthenticatedHttpClient().get(getValidationApiUrl(`${VALIDATION_API_PATH.VALIDATION_BODY}${params}`));
+  const { data } = await getAuthenticatedHttpClient({ useCache: true }).get(getValidationApiUrl(`${VALIDATION_API_PATH.VALIDATION_BODY}${params}`));
   return camelCaseObject(data);
 }
 


### PR DESCRIPTION
This PR makes an update in the course field behavior, where the dropdown was not being cleaned due to duplicated keys. The solution implemented uses the course ID as the key for the component.

Also, it removes the mandatory field validation in the comments field.

To validate this PR you can go to stage https://apps.unesco-stage.atlas.edunext.link/validation-panel 